### PR TITLE
Fix startup errors in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,12 @@
 import os
-
-# 作業ディレクトリを正しい場所に設定
-os.chdir('/workspaces/streamlit-app/streamlit-app/')
-print("Working Directory Set To:", os.getcwd())
-@st.cache_data
-
 import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
+
+# 作業ディレクトリをスクリプトの場所に設定
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+os.chdir(BASE_DIR)
+print("Working Directory Set To:", os.getcwd())
 
 # データの読み込み
 @st.cache_data


### PR DESCRIPTION
## Summary
- fix invalid decorator and use script dir for working directory

## Testing
- `python -m py_compile app.py`
- `python -m py_compile streamlit-app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68478abe6ed0832ca53a7470e559a611